### PR TITLE
18-base-apparel-coming-soon | swap in given error icon

### DIFF
--- a/18-base-apparel-coming-soon/index.css
+++ b/18-base-apparel-coming-soon/index.css
@@ -155,8 +155,8 @@ form.valid::after {
     align-items: center;
 }
 form.invalid::after {
-    content: "❕";
-    background: var(--color-error);
+    content: "";
+    background: url("./images/icon-error.svg") no-repeat;
 }
 
 form.valid::after {


### PR DESCRIPTION
Update: use given error icon

> with content value and background

<img width="1148" alt="Screenshot 2024-02-09 at 11 57 02 PM" src="https://github.com/gracepal/frontend-mentor/assets/131278381/ea4a5d47-921b-4183-b5c9-94baba954648">

> with dedicated error icon

<img width="1074" alt="Screenshot 2024-02-10 at 12 05 53 AM" src="https://github.com/gracepal/frontend-mentor/assets/131278381/ca07cfda-4925-4d2f-8cd5-b4345c628fa2">
